### PR TITLE
Offline Cache and Display

### DIFF
--- a/app/src/main/java/com/example/gufyguber/NavigationActivity.java
+++ b/app/src/main/java/com/example/gufyguber/NavigationActivity.java
@@ -20,10 +20,14 @@ import com.example.gufyguber.ui.Map.MapFragment;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.core.view.GravityCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.navigation.NavController;
@@ -40,6 +44,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import android.view.Menu;
+import android.widget.TextView;
+
+import java.util.Timer;
+import java.util.TimerTask;
 
 import static com.example.gufyguber.R.id.nav_host_fragment;
 

--- a/app/src/main/java/com/example/gufyguber/OfflineCache.java
+++ b/app/src/main/java/com/example/gufyguber/OfflineCache.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020  GufyGuber. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * OfflineCache.java
+ *
+ * Last edit: scott, 11/03/20 7:09 PM
+ *
+ * Version
+ */
+
+package com.example.gufyguber;
+
+public class OfflineCache {
+    private static OfflineCache reference;
+    public static OfflineCache getReference() {
+        if (reference == null) {
+            reference = new OfflineCache();
+        }
+        return reference;
+    }
+
+    private RideRequest currentRideRequest;
+
+    public void cacheCurrentRideRequest(RideRequest request) {
+        currentRideRequest = request;
+    }
+
+    public RideRequest retrieveCurrentRideRequest() {
+        return currentRideRequest;
+    }
+}

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -36,6 +36,16 @@
             android:layout_margin="@dimen/fab_margin"
             app:srcCompat="@android:drawable/ic_input_add" />
 
+        <TextView
+            android:id="@+id/offline_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:textColor="#FF0000"
+            android:textSize="20dp"
+            android:text="OFFLINE"/>
+
     </fragment>
 
 </FrameLayout>


### PR DESCRIPTION
- FAB replaced by "OFFLINE" text display when connectivity is interrupted
- Current ride request is cached when the rider creates a new one. Cache is used to display last cached version of request when offline